### PR TITLE
create sentry user as postgres superuser

### DIFF
--- a/ansible/roles/pgsql/tasks/main.yml
+++ b/ansible/roles/pgsql/tasks/main.yml
@@ -35,6 +35,7 @@
     password: '{{ pgsql.password }}'
     db: '{{ pgsql.database }}'
     priv: ALL
+    role_attr_flags: SUPERUSER
 
 - name: Set authentication config
   template: src={{ pgsql.auth_template }} dest=/etc/postgresql/9.4/main/pg_hba.conf

--- a/ansible/roles/supervisor/templates/sentry.conf.tpl
+++ b/ansible/roles/supervisor/templates/sentry.conf.tpl
@@ -1,5 +1,7 @@
 [program:sentry-web]
 directory={{ sentry.virtualenv }}
+environment=C_FORCE_ROOT="true"
+user=root
 command={{ sentry.virtualenv }}bin/sentry --config=/etc/sentry/sentry.conf.py run web
 autostart=true
 autorestart=true
@@ -9,7 +11,20 @@ stderr_logfile=syslog
 
 [program:sentry-worker]
 directory={{ sentry.virtualenv }}
-command={{ sentry.virtualenv }}bin/sentry --config=/etc/sentry/sentry.conf.py celery worker -B
+environment=C_FORCE_ROOT="true"
+user=root
+command={{ sentry.virtualenv }}bin/sentry --config=/etc/sentry/sentry.conf.py run worker
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:sentry-cron]
+directory={{ sentry.virtualenv }}
+environment=C_FORCE_ROOT="true"
+user=root
+command={{ sentry.virtualenv }}bin/sentry --config=/etc/sentry/sentry.conf.py run cron
 autostart=true
 autorestart=true
 redirect_stderr=true


### PR DESCRIPTION
without `role_attr_flags: SUPERUSER` option in playbook, provisioning fails at upgrade Sentry schema

```
TASK [sentry : Upgrade Sentry schema] ******************************************
fatal: [192.168.33.10]: FAILED! => {"changed": true, "cmd": ["/www/sentry/bin/sentry", 
"--config=/etc/sentry/sentry.conf.py", "upgrade", "--noinput"], 
"delta": "0:01:23.323603", "end": "2017-10-04 17:18:33.012600", "failed": true, "rc": 1, 
"start": "2017-10-04 17:17:09.688997", 
"stderr": "FATAL ERROR - The following SQL query failed: CREATE EXTENSION IF NOT EXISTS citext\n
The error was: permission denied to create extension \"citext\"\n
HINT:  Must be superuser to create this extension.\n\
```

